### PR TITLE
Use dbx file from specific suite

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run aws-secureboot-blob
         run: |
-          ./aws-secureboot-blob -a amd64 -o blob.amd64.bin
-          ./aws-secureboot-blob -a arm64 -o blob.arm64.bin
+          ./aws-secureboot-blob -s jammy -a amd64 -o blob.amd64.bin
+          ./aws-secureboot-blob -s jammy -a arm64 -o blob.arm64.bin
           # for debugging
           uefivars -i aws -o json -I blob.amd64.bin
           uefivars -i aws -o json -I blob.arm64.bin
@@ -81,6 +81,7 @@ jobs:
 
           # install tools for more checks
           apt update
+          apt-cache policy efitools
           apt install --yes efitools
 
           efi-readvar -v KEK

--- a/aws-secureboot-blob
+++ b/aws-secureboot-blob
@@ -8,8 +8,9 @@
 
 function create_blob() {
     local WORKDIR=$1
-    local ARCH=$2
-    local RESULT=$3
+    local SUITE=$2
+    local ARCH=$3
+    local RESULT=$4
 
     # Create an empty PK signature list
     touch "${WORKDIR}"/empty_key.crt
@@ -34,10 +35,10 @@ function create_blob() {
     # NOTE: we use the dbx file from ubuntu here
     case ${ARCH} in
         amd64)
-            curl -s https://git.launchpad.net/ubuntu/+source/secureboot-db/plain/data-amd64/updates/dbx/dbxupdate_x64.bin --output "${WORKDIR}"/dbxupdate.bin
+            curl -s https://git.launchpad.net/ubuntu/+source/secureboot-db/plain/data-amd64/updates/dbx/dbxupdate_x64.bin?h=ubuntu/"${SUITE}" --output "${WORKDIR}"/dbxupdate.bin
             ;;
         arm64)
-            curl -s https://git.launchpad.net/ubuntu/+source/secureboot-db/plain/data-arm64/updates/dbx/dbxupdate_arm64.bin --output "${WORKDIR}"/dbxupdate.bin
+            curl -s https://git.launchpad.net/ubuntu/+source/secureboot-db/plain/data-arm64/updates/dbx/dbxupdate_arm64.bin?h=ubuntu/"${SUITE}" --output "${WORKDIR}"/dbxupdate.bin
             ;;
         *)
             echo "Invalid arch ${ARCH}"
@@ -59,6 +60,7 @@ function usage() {
     usage: $0 [-a|o|h]
 
     options:
+        s    suite (eg. 'jammy' or 'jammy-updates'). default: jammy
         a    architecture (can be amd64 or arm64). default: amd64
         o    output filename. default: aws-uefiblob.bin
         h    this help
@@ -71,11 +73,13 @@ function cleanup {
 }
 
 
-while getopts "ho:a:" option; do
+while getopts "ho:s:a:" option; do
    case $option in
       h)
          usage
          exit;;
+      s)
+          SUITE=$OPTARG;;
       a)
           ARCH=$OPTARG;;
       o)
@@ -88,8 +92,9 @@ done
 
 TMPDIR=$(mktemp --directory aws-build-varstore-blob.XXXXXXXXXX)
 trap cleanup EXIT
+SUITE=${SUITE:-jammy}
 ARCH=${ARCH:-amd64}
 OUTPUT=${OUTPUT:-aws-uefiblob.bin}
 
 
-create_blob "${TMPDIR}" "${ARCH}" "${OUTPUT}"
+create_blob "${TMPDIR}" "${SUITE}" "${ARCH}" "${OUTPUT}"


### PR DESCRIPTION
The dbx file can be different between different suites. So allow to specify a suite which is then used to download the dbxupdate.bin file.