### PR TITLE
Create github release for tags

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,10 @@ name: Run tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+    tags:
+      - '*'
   pull_request:
     branches: [ main ]
 
@@ -47,6 +50,21 @@ jobs:
         run: |
           ./dbxupdate-split.py /usr/share/secureboot/updates/dbx/dbxupdate_x64.bin
           openssl asn1parse -inform DER -in dbxupdate.bin.p7
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: aws-test
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: blob-artifact
+          path: blobs
+      - name: create github release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            blobs/blob.amd64.bin
+            blobs/blob.arm64.bin
   aws-test:
     runs-on: ubuntu-latest
     needs: build-blob


### PR DESCRIPTION
With that, it's possible for users to directly download the binary blob which can be used then to create a secure-boot cabable AMI.