### PR TITLE
Wait for cloud-init to finish before running tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -106,6 +106,9 @@ jobs:
           cat << EOF > test.sh
           #!/bin/bash -eux
 
+          # wait for cloud-init to finish
+          cloud-init status --wait
+
           # secure boot should be enabled
           mokutil --sb-state|grep enabled
 


### PR DESCRIPTION
Without waiting, cloud-init didn't setup the in-cloud archive mirror. This fixes:

E: Unable to locate package efitools