### PR TITLE
Wait for cloud-init to finish before running tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo snap install uefivars
-          sudo apt install --yes efitools
+          sudo apt-get install --yes efitools
       - uses: actions/checkout@v2
       - name: Run aws-secureboot-blob
         run: |
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          sudo apt install --yes openssl
+          sudo apt-get install --yes openssl
       - name: Run dbxupdate-split
         run: |
           ./dbxupdate-split.py /usr/share/secureboot/updates/dbx/dbxupdate_x64.bin
@@ -113,9 +113,9 @@ jobs:
           mokutil --sb-state|grep enabled
 
           # install tools for more checks
-          apt update
+          apt-get update
           apt-cache policy efitools
-          apt install --yes efitools
+          apt-get install --yes efitools
 
           efi-readvar -v KEK
           efi-readvar -v db

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -106,6 +106,9 @@ jobs:
           cat << EOF > test.sh
           #!/bin/bash -eux
 
+          # wait for cloud-init to finish
+          cloud-init status --wait
+
           # secure boot should be enabled
           mokutil --sb-state|grep enabled
 


### PR DESCRIPTION
Without waiting, cloud-init didn't setup the in-cloud archive mirror. This fixes:

E: Unable to locate package efitools