### PR TITLE
ci: use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
           ./aws-secureboot-blob -o blob.bin
           # for debugging
           uefivars -i aws -o json -I blob.bin
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: blob-artifact
           path: blob.bin


### PR DESCRIPTION
actions/upload-artifact@v3 has been deprecated and requires migration to a new version.

Refs:
 * https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/