### PR TITLE
ci: upgrade to actions/download-artifact@v4

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: aws-test
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: blob-artifact
           path: blobs
@@ -73,7 +73,7 @@ jobs:
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: blob-artifact
           path: blobs


### PR DESCRIPTION
download-artifact@v3 has been deprecated and must be upgraded to v4 to continue using.

Refs:
 * https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/