### PR TITLE
docs: add contributing section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,15 @@ That will create the blob (by default for `amd64`) file called
 The blob can then be used during image registration. For details how
 to create a new AMI based on an existing Ubuntu AMI, see the `test-instance` script.
 
+
+## contributing
+
+We welcome external contributions. Before proposing changes please
+[create an issue](https://github.com/canonical/aws-secureboot-blob/issues/new?template=Blank+issue)
+describing the request. This helps ensure we prioritize accordingly and avoid duplicating effort.
+
+When a pull request is opened against this repository it is expected that it will fail
+when initiated from a fork. The pipeline tests secureboot in a Canonical provided AWS account,
+which is not allowed to be launched from a fork. Changes from external contributors will be manually tested
+Maintainers of this repository should push their branches to origin to allow for end to end testing
+in the pull request.


### PR DESCRIPTION
this adds a short contributing section to the readme clarifying PR expectations and how maintainers should initiate pull request.

ironically not following contributing to avoid the extra compute :)